### PR TITLE
Integrate recipe genre and update schemas

### DIFF
--- a/app/api/recipes/route.ts
+++ b/app/api/recipes/route.ts
@@ -65,8 +65,8 @@ const recipeSchema = z.object({
   instructions: z.array(instructionObjectSchema).describe("Liste d'instructions, chaque instruction est un objet avec texte et ordre."),
   description: z.string().describe("Courte description de la recette."),
   servings: z.number().describe("Nombre de portions de la recette. Toujours 1."),
-  prep_time_minutes: z.number().describe("Temps de préparation en minutes."),
-  cook_time_minutes: z.number().describe("Temps de cuisson en minutes."),
+  preparationTime: z.number().describe("Temps de préparation en minutes."),
+  cookingTime: z.number().describe("Temps de cuisson en minutes."),
 });
 const recipesSchema = z.object({
   recipes: z.array(recipeSchema)
@@ -210,8 +210,8 @@ export async function POST(req: Request) {
           ],
           "description": "Description courte de la recette",
           "servings": ${servings},
-          "prep_time_minutes": 15,
-          "cook_time_minutes": 30
+          "preparationTime": 15,
+          "cookingTime": 30
         }
       ]
     }
@@ -223,8 +223,8 @@ export async function POST(req: Request) {
     - instructions : array d'objets avec text (string) et order (number)
     - description : description courte (string)
     - servings : ${servings} (number)
-    - prep_time_minutes : temps préparation en minutes (number)
-    - cook_time_minutes : temps cuisson en minutes (number)
+    - preparationTime : temps préparation en minutes (number)
+    - cookingTime : temps cuisson en minutes (number)
 
     EXEMPLES DE BONNES PRATIQUES (en français) :
     - Avec pomme + banane → Smoothie pomme-banane + Compote de fruits mixés

--- a/app/components/RecipeCard.tsx
+++ b/app/components/RecipeCard.tsx
@@ -2,15 +2,16 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { Trash2, Clock, Users, ChefHat, Save } from "lucide-react";
+import { Trash2, Clock, Users, ChefHat, Save, BookOpen } from "lucide-react";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { RecipeCard as RecipeType } from "@/schemas/api";
 
 interface RecipeCardProps {
-  recipe: Record<string, unknown>;
+  recipe: RecipeType;
   onDelete?: (recipeId: string) => void;
   showDeleteButton?: boolean;
   showSaveButton?: boolean;
@@ -23,17 +24,16 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  // Extract recipe data with proper typing and Airtable compatibility
-  const title = (recipe.title as string) || ((recipe.fields as any)?.Title as string) || "Recette sans titre";
-  const description = (recipe.description as string) || ((recipe.fields as any)?.Description as string) || "";
-  const ingredients = (recipe.ingredients as Array<{ name: string; quantity: number; unit: string }>) || [];
-  const instructions = (recipe.instructions as Array<{ text: string; order: number }>) || [];
-  const servings = (recipe.servings as number) || ((recipe.fields as any)?.Servings as number) || 1;
-  const difficulty = (recipe.difficulty as string) || "Moyenne";
-  const cuisine = (recipe.cuisine as string) || "Française";
-  const recipeId = (recipe.id as string) || "";
-  const prepTime = (recipe.prep_time_minutes as number) || ((recipe.fields as any)?.PrepTimeMinutes as number) || 0;
-  const cookTime = (recipe.cook_time_minutes as number) || ((recipe.fields as any)?.CookTimeMinutes as number) || 0;
+  const title = recipe.title || recipe.fields?.Title || "Recette sans titre";
+  const description = recipe.description || recipe.fields?.Description || "";
+  const ingredients = recipe.ingredients || [];
+  const instructions = recipe.instructions || [];
+  const servings = recipe.servings ?? recipe.fields?.Servings ?? 1;
+  const difficulty = recipe.difficulty || "Moyenne";
+  const cuisine = recipe.cuisine || "Française";
+  const recipeId = recipe.id || "";
+  const prepTime = recipe.preparationTime ?? recipe.fields?.PreparationTime ?? 0;
+  const cookTime = recipe.cookingTime ?? recipe.fields?.CookingTime ?? 0;
 
   const handleSaveRecipe = async () => {
     setIsSaving(true);
@@ -52,8 +52,8 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
             servings,
             difficulty,
             cuisine,
-            prep_time_minutes: prepTime,
-            cook_time_minutes: cookTime,
+            preparationTime: prepTime,
+            cookingTime: cookTime,
           },
         }),
       });
@@ -67,7 +67,7 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
       } else {
         toast.error("Erreur lors de la sauvegarde");
       }
-    } catch (error) {
+    } catch {
       toast.error("Erreur lors de la sauvegarde");
     } finally {
       setIsSaving(false);
@@ -93,7 +93,7 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
       } else {
         toast.error("Erreur lors de la suppression");
       }
-    } catch (error) {
+    } catch {
       toast.error("Erreur lors de la suppression");
     } finally {
       setIsDeleting(false);
@@ -183,7 +183,17 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
               variant="ghost"
               className="btn-ghost flex-1 sm:flex-none"
             >
-              {isExpanded ? "👁️ Masquer" : "👁️ Voir les détails"}
+              {isExpanded ? (
+                <div className="flex items-center gap-1">
+                  <BookOpen className="w-3 h-3" />
+                  <span className="text-xs hidden sm:inline">Hide</span>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1">
+                  <BookOpen className="w-3 h-3" />
+                  <span className="text-xs hidden sm:inline">Details</span>
+                </div>
+              )}
             </Button>
           </div>
         </div>
@@ -374,7 +384,17 @@ export function RecipeCard({ recipe, onDelete, showDeleteButton = false, showSav
             variant="ghost"
             className="hover-lift bg-white/90 backdrop-blur-sm"
           >
-            {isExpanded ? "👁️ Masquer" : "👁️ Voir détails"}
+            {isExpanded ? (
+              <div className="flex items-center gap-1">
+                <BookOpen className="w-3 h-3" />
+                <span className="text-xs">Hide</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1">
+                <BookOpen className="w-3 h-3" />
+                <span className="text-xs">Details</span>
+              </div>
+            )}
           </Button>
         </div>
 

--- a/app/ingredients/page.tsx
+++ b/app/ingredients/page.tsx
@@ -1,26 +1,21 @@
 'use client';
 
 import { useEffect, useState } from "react";
+import { fetchIngredientOptions } from "@/lib/api";
+import { IngredientOption } from "@/schemas/api";
 
 export default function IngredientsPage() {
-    // get all ingredients from Airtable
-    const [ingredients, setIngredients] = useState([]);
+    const [ingredients, setIngredients] = useState<IngredientOption[]>([]);
 
     useEffect(() => {
-        const fetchIngredients = async () => {
+        const load = async () => {
             try {
-                const response = await fetch('/api/ingredients');
-                if (!response.ok) {
-                    throw new Error('Network response was not ok');
-                }
-                const data = await response.json();
+                const data = await fetchIngredientOptions();
                 setIngredients(data);
-            } catch (error) {
-                console.error('Error fetching ingredients:', error);
-            }
+            } catch {}
         };
 
-        fetchIngredients();
+        load();
     }, []);
 
     return (
@@ -31,9 +26,7 @@ export default function IngredientsPage() {
 
             <ul>
                 {ingredients && ingredients.map((ingredient) => (
-                    <li key={ingredient.id}>
-                        {ingredient.fields.Name} - {ingredient.fields.Description}
-                    </li>
+                    <li key={ingredient.value}>{ingredient.label}</li>
                 ))}
             </ul>
         </div>

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -80,8 +80,8 @@ interface Recipe {
     Title?: string;
     Description?: string;
     Servings?: number;
-    PrepTimeMinutes?: number;
-    CookTimeMinutes?: number;
+    PreparationTime?: number;
+    CookingTime?: number;
     Recipes_Ingredients?: string[];
     Recipe_Instructions?: string[];
   };
@@ -99,8 +99,8 @@ interface Recipe {
   }>;
   intolerances?: string[];
   servings?: number;
-  prep_time_minutes?: number;
-  cook_time_minutes?: number;
+  preparationTime?: number;
+  cookingTime?: number;
   created_at?: string;
   nutrition?: NutritionData;
 }
@@ -262,12 +262,12 @@ export default function RecipeDetailPage() {
 
   // Helper function to get recipe prep time
   const getRecipePrepTime = (recipe: Recipe) => {
-    return recipe.prep_time_minutes || recipe.fields?.PrepTimeMinutes;
+    return recipe.preparationTime || recipe.fields?.PreparationTime;
   };
 
   // Helper function to get recipe cook time
   const getRecipeCookTime = (recipe: Recipe) => {
-    return recipe.cook_time_minutes || recipe.fields?.CookTimeMinutes;
+    return recipe.cookingTime || recipe.fields?.CookingTime;
   };
 
   // Helper function to get recipe creation date

--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -9,49 +9,23 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Plus, ChefHat } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
-
-interface Recipe extends Record<string, unknown> {
-  id: string;
-  fields?: {
-    Title?: string;
-    Description?: string;
-    Servings?: number;
-    PrepTimeMinutes?: number;
-    CookTimeMinutes?: number;
-  };
-  ingredients?: Array<{
-    id: string;
-    name: string;
-    quantity?: number;
-    unit?: string;
-  }>;
-  instructions?: Array<{
-    text: string;
-    order: number;
-  }>;
-  servings?: number;
-  prep_time_minutes?: number;
-  cook_time_minutes?: number;
-  title?: string;
-  description?: string;
-}
+import { fetchRecipes as getRecipes } from "@/lib/api";
+import { RecipeCard as RecipeType } from "@/schemas/api";
 
 export default function RecipesPage() {
-  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [recipes, setRecipes] = useState<RecipeType[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchRecipes();
+    loadRecipes();
   }, []);
 
-  const fetchRecipes = async () => {
+  const loadRecipes = async () => {
     try {
       setLoading(true);
-      const response = await fetch('/api/recipes');
-      if (!response.ok) throw new Error('Failed to fetch recipes');
-      const data = await response.json();
-      setRecipes(Array.isArray(data) ? data : []);
+      const data = await getRecipes();
+      setRecipes(data);
     } catch (err) {
       const error = err as Error;
       setError(error.message || 'Failed to load recipes');
@@ -97,7 +71,7 @@ export default function RecipesPage() {
           <div className="max-w-4xl mx-auto text-center">
             <h1 className="text-2xl font-bold text-red-600 mb-4">Erreur</h1>
             <p className="text-muted-foreground mb-6">{error}</p>
-            <Button onClick={fetchRecipes} variant="outline">
+            <Button onClick={loadRecipes} variant="outline">
               Réessayer
             </Button>
           </div>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,25 @@
+import { airtableIngredientRecordSchema, ingredientOptionSchema, recipeCardSchema, RecipeCard, IngredientOption } from '@/schemas/api';
+import { z } from 'zod';
+
+export const fetchIngredientOptions = async (): Promise<IngredientOption[]> => {
+  const res = await fetch('/api/ingredients');
+  if (!res.ok) throw new Error('Failed to fetch ingredients');
+  const data = await res.json();
+  const records = z.array(airtableIngredientRecordSchema).parse(data);
+  return records.map(r => ingredientOptionSchema.parse({ label: r.fields?.Name ?? r.id, value: r.id }));
+};
+
+export const generateRecipes = async (payload: { ingredients: { id: string; name: string }[]; intolerances: string[]; servings: number; genre?: string; }): Promise<RecipeCard[]> => {
+  const res = await fetch('/api/recipes', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+  if (!res.ok) throw new Error('Failed to generate recipe');
+  const data = await res.json();
+  const parsed = z.object({ recipes: z.array(recipeCardSchema) }).parse(data);
+  return parsed.recipes;
+};
+
+export const fetchRecipes = async (): Promise<RecipeCard[]> => {
+  const res = await fetch('/api/recipes');
+  if (!res.ok) throw new Error('Failed to fetch recipes');
+  const data = await res.json();
+  return z.array(recipeCardSchema).parse(data);
+};

--- a/schemas/api/index.ts
+++ b/schemas/api/index.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+export const airtableIngredientRecordSchema = z.object({
+  id: z.string(),
+  fields: z.object({ Name: z.string().optional() }).optional(),
+});
+
+export const ingredientOptionSchema = z.object({
+  label: z.string(),
+  value: z.string(),
+});
+export type IngredientOption = z.infer<typeof ingredientOptionSchema>;
+
+const recipeIngredientSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  quantity: z.number().optional(),
+  unit: z.string().optional(),
+});
+
+const instructionSchema = z.object({
+  text: z.string(),
+  order: z.number(),
+});
+
+export const recipeCardSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  ingredients: z.array(recipeIngredientSchema).optional(),
+  instructions: z.array(instructionSchema).optional(),
+  servings: z.number().optional(),
+  preparationTime: z.number().optional(),
+  cookingTime: z.number().optional(),
+  difficulty: z.string().optional(),
+  cuisine: z.string().optional(),
+  fields: z.object({
+    Title: z.string().optional(),
+    Description: z.string().optional(),
+    Servings: z.number().optional(),
+    PreparationTime: z.number().optional(),
+    CookingTime: z.number().optional(),
+  }).optional(),
+});
+export type RecipeCard = z.infer<typeof recipeCardSchema>;


### PR DESCRIPTION
## Summary
- support `preparationTime` and `cookingTime` fields
- allow specifying recipe genre on the home page
- update typed API helpers
- refresh detail and card components
- swap eye emoji for BookOpen icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686fdbd372c483328b2fbd218853ebbb