### PR TITLE
Improve Airtable fetches and pagination

### DIFF
--- a/api/recipeIngredients.ts
+++ b/api/recipeIngredients.ts
@@ -1,11 +1,17 @@
 'use server'
 
-import { getRecords, createRecords } from '@/lib/axios'
+import { getRecords, createRecords, GetRecordsOptions } from '@/lib/axios'
 import { AirtableTables } from '@/constants/airtable'
 import { JoinRecord } from '@/lib/types'
 
-export const fetchRecipeIngredientJoins = async (): Promise<JoinRecord[]> => {
-  const records = await getRecords(AirtableTables.RECIPE_INGREDIENT)
+export const fetchRecipeIngredientJoins = async (
+  recipeId?: string
+): Promise<JoinRecord[]> => {
+  const options: GetRecordsOptions = {}
+  if (recipeId) {
+    options.filterByFormula = `FIND("${recipeId}", ARRAYJOIN({Recipe}, ","))`
+  }
+  const records = await getRecords(AirtableTables.RECIPE_INGREDIENT, options)
   return records as JoinRecord[]
 }
 

--- a/api/recipeIngredients.ts
+++ b/api/recipeIngredients.ts
@@ -9,7 +9,7 @@ export const fetchRecipeIngredientJoins = async (
 ): Promise<JoinRecord[]> => {
   const options: GetRecordsOptions = {}
   if (recipeId) {
-    options.filterByFormula = `FIND("${recipeId}", ARRAYJOIN({Recipe}, ","))`
+    options.filterByFormula = `{Recipes} = "${recipeId}"`
   }
   const records = await getRecords(AirtableTables.RECIPE_INGREDIENT, options)
   return records as JoinRecord[]

--- a/api/recipeInstructions.ts
+++ b/api/recipeInstructions.ts
@@ -1,18 +1,22 @@
 'use server'
 
-import { getRecords, createRecords, GetRecordsOptions } from '@/lib/axios'
+import {createRecords, getRecords, GetRecordsOptions} from '@/lib/axios'
 import { AirtableTables } from '@/constants/airtable'
 import { InstructionRecord } from '@/lib/types'
 
 export const fetchRecipeInstructions = async (
-  recipeId?: string
+    recipeId?: string
 ): Promise<InstructionRecord[]> => {
   const options: GetRecordsOptions = {}
   if (recipeId) {
-    options.filterByFormula = `FIND("${recipeId}", ARRAYJOIN({Recipe}, ","))`
-    options.sort = [{ field: 'Order', direction: 'asc' }]
+    options.filterByFormula = `{Recipes} = "${recipeId}"`
   }
-  const records = await getRecords(AirtableTables.RECIPE_INSTRUCTIONS, options)
+  options.sort = [{ field: 'Order', direction: 'asc' }]
+
+  const records = await getRecords(
+      AirtableTables.RECIPE_INSTRUCTIONS,
+      options
+  )
   return records as InstructionRecord[]
 }
 

--- a/api/recipeInstructions.ts
+++ b/api/recipeInstructions.ts
@@ -1,11 +1,18 @@
 'use server'
 
-import { getRecords, createRecords } from '@/lib/axios'
+import { getRecords, createRecords, GetRecordsOptions } from '@/lib/axios'
 import { AirtableTables } from '@/constants/airtable'
 import { InstructionRecord } from '@/lib/types'
 
-export const fetchRecipeInstructions = async (): Promise<InstructionRecord[]> => {
-  const records = await getRecords(AirtableTables.RECIPE_INSTRUCTIONS)
+export const fetchRecipeInstructions = async (
+  recipeId?: string
+): Promise<InstructionRecord[]> => {
+  const options: GetRecordsOptions = {}
+  if (recipeId) {
+    options.filterByFormula = `FIND("${recipeId}", ARRAYJOIN({Recipe}, ","))`
+    options.sort = [{ field: 'Order', direction: 'asc' }]
+  }
+  const records = await getRecords(AirtableTables.RECIPE_INSTRUCTIONS, options)
   return records as InstructionRecord[]
 }
 

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -36,7 +36,6 @@ export default function RecipeDetailPage() {
     const fetchRecipe = async () => {
       try {
         const data = await getRecipe(recipeId);
-        console.log('Fetched recipe:', data);
         setRecipe(data);
       } catch (err) {
         const error = err as Error;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,11 +4,7 @@ export interface AirtableRecord {
   fields?: Record<string, unknown>;
 }
 
-export interface IngredientRecord extends AirtableRecord {
-  fields?: {
-    Name?: string;
-  };
-}
+
 
 export interface RecipeRecord extends AirtableRecord {
   fields?: {
@@ -17,12 +13,20 @@ export interface RecipeRecord extends AirtableRecord {
     Serving?: number;
     PrepTimeMinutes?: number;
     CookTimeMinutes?: number;
+    Difficulty?: string;
+    Cuisine?: string;
+  };
+}
+
+export interface IngredientRecord extends AirtableRecord {
+  fields?: {
+    Name?: string;
   };
 }
 
 export interface JoinRecord extends AirtableRecord {
   fields?: {
-    Recipe?: string[];
+    Recipes?: string[];
     Ingredient?: string[];
     Quantity?: number | string;
     Unit?: string;
@@ -32,7 +36,7 @@ export interface JoinRecord extends AirtableRecord {
 
 export interface InstructionRecord extends AirtableRecord {
   fields?: {
-    Recipe?: string[];
+    Recipes?: string[];
     Instruction?: string;
     Order?: number;
   };
@@ -79,7 +83,7 @@ export interface RecipeIngredientRecord {
   createdTime: string;
   fields: {
     Identifier: number;
-    Recipe: string[];
+    Recipes: string[];
     Ingredient: string[];
     Quantity: number;
     Unit: string;
@@ -93,7 +97,7 @@ export interface RecipeInstructionRecord {
   fields: {
     Instruction: string;
     Order: number;
-    Recipe: string[];
+    Recipes: string[];
   };
 }
 

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -19,8 +19,9 @@ const recipeIngredientSchema = z.object({
 });
 
 const instructionSchema = z.object({
-  text: z.string(),
+  instruction: z.string(),
   order: z.number(),
+  recipes: z.array(z.string()).optional(),
 });
 
 export const recipeCardSchema = z.object({


### PR DESCRIPTION
## Summary
- support pagination in Airtable requests
- fetch joins for a specific recipe only
- clean up console logs

## Testing
- `npm install`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68700b0fbf50833280f4e3b3836d96db