### PR TITLE
Fix TypeScript errors and unify types

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -172,9 +172,9 @@ export default function RecipeDetailPage() {
     if (recipe.recipe_ingredient_quantity_records) {
       return recipe.recipe_ingredient_quantity_records.map(record => ({
         id: record.id,
-        name: record.ingredientName || `Ingrédient ${record.fields.Identifier}`,
-        quantity: record.fields.Quantity,
-        unit: record.fields.Unit
+        name: record.ingredientName || `Ingrédient ${record.fields?.Identifier ?? ''}`,
+        quantity: record.fields?.Quantity,
+        unit: record.fields?.Unit
       }));
     }
     
@@ -186,10 +186,10 @@ export default function RecipeDetailPage() {
     
     if (recipe.recipe_instruction_records) {
       return recipe.recipe_instruction_records
-        .sort((a, b) => a.fields.Order - b.fields.Order)
+        .sort((a, b) => (a.fields?.Order ?? 0) - (b.fields?.Order ?? 0))
         .map(record => ({
-          text: record.fields.Instruction,
-          order: record.fields.Order
+          text: record.fields?.Instruction ?? '',
+          order: record.fields?.Order ?? 0
         }));
     }
     

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,134 +1,157 @@
-export interface AirtableRecord {
-  id: string;
-  createdTime?: string;
-  fields?: Record<string, unknown>;
-}
+import { z } from 'zod'
 
+export const airtableRecordSchema = z.object({
+  id: z.string(),
+  createdTime: z.string().optional(),
+  fields: z.record(z.unknown()).optional()
+})
+export type AirtableRecord = z.infer<typeof airtableRecordSchema>
 
+export const recipeRecordSchema = airtableRecordSchema.extend({
+  fields: z
+    .object({
+      Title: z.string().optional(),
+      Description: z.string().optional(),
+      Serving: z.number().optional(),
+      PrepTimeMinutes: z.number().optional(),
+      CookTimeMinutes: z.number().optional(),
+      Difficulty: z.string().optional(),
+      Cuisine: z.string().optional()
+    })
+    .optional()
+})
+export type RecipeRecord = z.infer<typeof recipeRecordSchema>
 
-export interface RecipeRecord extends AirtableRecord {
-  fields?: {
-    Title?: string;
-    Description?: string;
-    Serving?: number;
-    PrepTimeMinutes?: number;
-    CookTimeMinutes?: number;
-    Difficulty?: string;
-    Cuisine?: string;
-  };
-}
+export const ingredientRecordSchema = airtableRecordSchema.extend({
+  fields: z.object({ Name: z.string().optional() }).optional()
+})
+export type IngredientRecord = z.infer<typeof ingredientRecordSchema>
 
-export interface IngredientRecord extends AirtableRecord {
-  fields?: {
-    Name?: string;
-  };
-}
+export const joinRecordSchema = airtableRecordSchema.extend({
+  fields: z
+    .object({
+      Recipes: z.array(z.string()).optional(),
+      Ingredient: z.array(z.string()).optional(),
+      Quantity: z.union([z.number(), z.string()]).optional(),
+      Unit: z.string().optional(),
+      Identifier: z.number().optional()
+    })
+    .optional()
+})
+export type JoinRecord = z.infer<typeof joinRecordSchema>
 
-export interface JoinRecord extends AirtableRecord {
-  fields?: {
-    Recipes?: string[];
-    Ingredient?: string[];
-    Quantity?: number | string;
-    Unit?: string;
-    Identifier?: number;
-  };
-}
+export const instructionRecordSchema = airtableRecordSchema.extend({
+  fields: z
+    .object({
+      Recipes: z.array(z.string()).optional(),
+      Instruction: z.string().optional(),
+      Order: z.number().optional()
+    })
+    .optional()
+})
+export type InstructionRecord = z.infer<typeof instructionRecordSchema>
 
-export interface InstructionRecord extends AirtableRecord {
-  fields?: {
-    Recipes?: string[];
-    Instruction?: string;
-    Order?: number;
-  };
-}
+export const nutritionDataSchema = z.object({
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+  fiber: z.number(),
+  sugar: z.number(),
+  sodium: z.number(),
+  vitamins: z.object({
+    A: z.number().optional(),
+    C: z.number().optional(),
+    D: z.number().optional(),
+    E: z.number().optional(),
+    K: z.number().optional(),
+    B1: z.number().optional(),
+    B2: z.number().optional(),
+    B3: z.number().optional(),
+    B6: z.number().optional(),
+    B12: z.number().optional(),
+    folate: z.number().optional()
+  }),
+  minerals: z.object({
+    calcium: z.number().optional(),
+    iron: z.number().optional(),
+    magnesium: z.number().optional(),
+    phosphorus: z.number().optional(),
+    potassium: z.number().optional(),
+    zinc: z.number().optional(),
+    copper: z.number().optional(),
+    manganese: z.number().optional(),
+    selenium: z.number().optional()
+  }),
+  nutrition_notes: z.string().optional(),
+  nutrition_score: z.number().optional()
+})
+export type NutritionData = z.infer<typeof nutritionDataSchema>
 
-export interface NutritionData {
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  fiber: number;
-  sugar: number;
-  sodium: number;
-  vitamins: {
-    A?: number;
-    C?: number;
-    D?: number;
-    E?: number;
-    K?: number;
-    B1?: number;
-    B2?: number;
-    B3?: number;
-    B6?: number;
-    B12?: number;
-    folate?: number;
-  };
-  minerals: {
-    calcium?: number;
-    iron?: number;
-    magnesium?: number;
-    phosphorus?: number;
-    potassium?: number;
-    zinc?: number;
-    copper?: number;
-    manganese?: number;
-    selenium?: number;
-  };
-  nutrition_notes?: string;
-  nutrition_score?: number;
-}
+export const recipeIngredientRecordSchema = airtableRecordSchema.extend({
+  fields: z
+    .object({
+      Identifier: z.number(),
+      Recipes: z.array(z.string()),
+      Ingredient: z.array(z.string()),
+      Quantity: z.number(),
+      Unit: z.string()
+    })
+    .optional(),
+  ingredientName: z.string().optional()
+})
+export type RecipeIngredientRecord = z.infer<typeof recipeIngredientRecordSchema>
 
-export interface RecipeIngredientRecord {
-  id: string;
-  createdTime: string;
-  fields: {
-    Identifier: number;
-    Recipes: string[];
-    Ingredient: string[];
-    Quantity: number;
-    Unit: string;
-  };
-  ingredientName?: string;
-}
+export const recipeInstructionRecordSchema = airtableRecordSchema.extend({
+  fields: z
+    .object({
+      Instruction: z.string(),
+      Order: z.number(),
+      Recipes: z.array(z.string())
+    })
+    .optional()
+})
+export type RecipeInstructionRecord = z.infer<typeof recipeInstructionRecordSchema>
 
-export interface RecipeInstructionRecord {
-  id: string;
-  createdTime: string;
-  fields: {
-    Instruction: string;
-    Order: number;
-    Recipes: string[];
-  };
-}
-
-export interface Recipe {
-  id: string;
-  createdTime?: string;
-  fields?: {
-    Title?: string;
-    Description?: string;
-    Serving?: number;
-    PreparationTime?: number;
-    CookingTime?: number;
-    Recipes_Ingredients?: string[];
-    Recipe_Instructions?: string[];
-  };
-  recipe_ingredient_quantity_records?: RecipeIngredientRecord[];
-  recipe_instruction_records?: RecipeInstructionRecord[];
-  ingredients?: Array<{
-    id: string;
-    name: string;
-    quantity?: number;
-    unit?: string;
-  }>;
-  instructions?: Array<{
-    text: string;
-    order: number;
-  }>;
-  intolerances?: string[];
-  serving?: number;
-  preparationTime?: number;
-  cookingTime?: number;
-  created_at?: string;
-  nutrition?: NutritionData;
-}
+export const recipeSchema = z.object({
+  id: z.string(),
+  createdTime: z.string().optional(),
+  fields: z
+    .object({
+      Title: z.string().optional(),
+      Description: z.string().optional(),
+      Serving: z.number().optional(),
+      PreparationTime: z.number().optional(),
+      CookingTime: z.number().optional(),
+      Recipes_Ingredients: z.array(z.string()).optional(),
+      Recipe_Instructions: z.array(z.string()).optional()
+    })
+    .optional(),
+  recipe_ingredient_quantity_records: z.array(recipeIngredientRecordSchema).optional(),
+  recipe_instruction_records: z.array(recipeInstructionRecordSchema).optional(),
+  ingredients: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        quantity: z.number().optional(),
+        unit: z.string().optional()
+      })
+    )
+    .optional(),
+  instructions: z
+    .array(
+      z.object({
+        text: z.string(),
+        order: z.number()
+      })
+    )
+    .optional(),
+  intolerances: z.array(z.string()).optional(),
+  serving: z.number().optional(),
+  preparationTime: z.number().optional(),
+  cookingTime: z.number().optional(),
+  created_at: z.string().optional(),
+  nutrition: nutritionDataSchema.optional()
+})
+export type Recipe = z.infer<typeof recipeSchema>

--- a/schemas/index.ts
+++ b/schemas/index.ts
@@ -19,7 +19,7 @@ const recipeIngredientSchema = z.object({
 });
 
 const instructionSchema = z.object({
-  instruction: z.string(),
+  text: z.string(),
   order: z.number(),
   recipes: z.array(z.string()).optional(),
 });


### PR DESCRIPTION
## Summary
- simplify type system using Zod schemas and type aliases
- adjust recipe schema to use `text` for instructions
- update API helpers to use new types and safe property access
- fix optional chaining issues in recipe detail page

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68701d1aa3a48332990ba42ebe8b88ec